### PR TITLE
Fixes

### DIFF
--- a/resources/bin/clean-zsh
+++ b/resources/bin/clean-zsh
@@ -1,0 +1,9 @@
+#!/bin/zsh
+SHELL=/bin/zsh
+cd
+exec /usr/bin/env -i HOME="$HOME" LOGNAME=$LOGNAME USER=$USER \
+    PATH=/usr/bin:/bin \
+    SHELL="$SHELL" \
+    SHLVL=$(( $SHLVL-1 )) \
+    TERM="$TERM" \
+    "$SHELL" "$@"

--- a/resources/condarc.m4
+++ b/resources/condarc.m4
@@ -1,6 +1,0 @@
-channels:
-  - conda-forge
-envs_dirs:
-  - RESOLVED_TARGET/infrastructure/ENVIRONMENT_NAME/conda/envs
-pkgs_dirs:
-  - RESOLVED_TARGET/conda_package_cache

--- a/resources/defs/universal/unix.yaml
+++ b/resources/defs/universal/unix.yaml
@@ -5,6 +5,7 @@ dependencies:
   - broot
   - exa
   - fzf
+  - git-delta
   - git-lfs
   - lftp
   - mc

--- a/resources/etc/profile.d/ca.sh
+++ b/resources/etc/profile.d/ca.sh
@@ -1,0 +1,63 @@
+# Local support for conda
+# Add two commands:
+#
+# cda: a wrapper for "conda deactivate"
+#
+# ca: a wrapper function for "conda activate" that simplifies the PS1 prompt
+# when the environment is specified by path, as indicated by a slash.
+#
+# The ca function supports tab-completion using the contents of the directory
+# "${IAC_PARENT}/users/${USER}/conda/envs"
+#
+# Additional the alias "reload-ca" will reload this file.
+
+alias reload-ca="source '$0'"
+
+alias cda='conda deactivate'
+
+ca() {
+    local __SAVE_PS1="$PS1"
+    conda activate "$@"
+    if [[ $? == 0 ]]; then
+        if [[ "$CONDA_DEFAULT_ENV" =~ .*/.* ]]; then
+            local new_mod="(.../$(basename "$CONDA_DEFAULT_ENV")) "
+            PS1="$new_mod$__SAVE_PS1"
+            export CONDA_PROMPT_MODIFIER="$new_mod"
+        fi
+    else
+        PS1="$__SAVE_PS1"
+    fi
+}
+
+if [[ $ZSH_NAME ]]; then
+    # Define the zsh completer function
+    _ca_complete() {
+        local envs
+        if [[ $words[2] == */* ]]; then
+            _files -W -g "$words[2]*(-/)" -/ -o nosort
+        else
+            envs=( $(ls "${IAC_PARENT}/users/${USER}/conda/envs") )
+            _arguments "1: :($(echo $envs))"
+            # _files -W -g "${IAC_PARENT}/users/${USER}/conda/envs/$words[2]*(-/)" -/ -o nosort
+        fi
+    }
+
+    # Register the completer function for the "ca" function
+    compdef _ca_complete ca
+fi
+
+if [[ $BASH ]]; then
+    # Define the bash completer function
+    _ca_complete() {
+        local envs
+        if [[ $COMP_WORDS[COMP_CWORD] == */* ]]; then
+            COMPREPLY=( $(compgen -d "$COMP_WORDS[COMP_CWORD]" ) )
+        else
+            envs=( $(ls "${IAC_PARENT}/users/${USER}/conda/envs") )
+            COMPREPLY=( $(compgen -W "$(echo ${envs[*]})" -- "${COMP_WORDS[COMP_CWORD]}" ) )
+        fi
+    }
+
+    # Register the completer function for the "ca" function
+    complete -F _ca_complete ca
+fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -127,7 +127,7 @@ setup_target() {
             rm -rf infrastructure
         fi
     fi
-    mkdir -p conda_package_cache engine_home infrastructure user_envs
+    mkdir -p conda_package_cache engine_home infrastructure
     cd infrastructure
     mkdir -p blue green testing blue/{bin,etc} blue/conda/{def,envs}
     ln -s blue staging

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -46,7 +46,7 @@ main() {
     fi
 
     info "${BLUE}Read parameters:${NOFORMAT}"
-    dump_vars VERBOSE FORCE OFFLINE KEEP NO_INSTALLS TARGET_DIR
+    dump_vars VERBOSE FORCE OFFLINE KEEP NO_INSTALLS TARGET_DIR CONDA_SUBDIR
     msg
 
     SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -19,7 +19,7 @@ Available options:
 -h, --help          Print this help and exit.
 -v, --verbose       Print script debug info.
 --no-color          Turn off color output.
---force             Force overwriting existing infrastructure!
+--force             Erase existing tier in current infrastructure!
 --offline           No internet usage
 -k, --keep          Keep and use current deployment engine
 -n, --no-installs   No conda or pip installs, just skeleton
@@ -123,8 +123,7 @@ setup_target() {
         if [[ -z $FORCE ]]; then
             die "$TARGET_DIR/infrastructure already exists"
         else
-            warning "overwriting $RESOLVED_TARGET/infrastructure"
-            rm -rf infrastructure
+            warning "Overwriting $RESOLVED_TARGET/infrastructure"
         fi
     fi
     mkdir -p conda_package_cache engine_home infrastructure

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -129,7 +129,9 @@ setup_target() {
     mkdir -p conda_package_cache engine_home infrastructure
     cd infrastructure
     mkdir -p blue green testing blue/{bin,etc} blue/conda/{def,envs}
-    ln -s blue staging
+    if [[ ! -f staging ]]; then
+        ln -s blue staging
+    fi
 }
 
 get_conda() {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -128,8 +128,8 @@ setup_target() {
     fi
     mkdir -p conda_package_cache engine_home infrastructure
     cd infrastructure
-    mkdir -p blue green testing blue/{bin,etc} blue/conda/{def,envs}
-    if [[ ! -f staging ]]; then
+    mkdir -p blue green testing
+    if [[ ! -e staging ]]; then
         ln -s blue staging
     fi
 }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -22,7 +22,7 @@ Available options:
 --force             Force overwriting existing infrastructure!
 --offline           No internet usage
 -k, --keep          Keep and use current deployment engine
--n, --no-installs   No conda or pip installs, just skeleton and condarc
+-n, --no-installs   No conda or pip installs, just skeleton
 
 Environment:
 CONDA: optional path to a conda executable
@@ -62,7 +62,6 @@ main() {
     export CONDA_ENVS_DIRS="$RESOLVED_TARGET/infrastructure/production/conda/envs"
     export CONDA_PKGS_DIRS="$RESOLVED_TARGET"/conda_package_cache
     export HOME="$RESOLVED_TARGET"/engine_home
-    export CONDARC="$RESOLVED_TARGET"/infrastructure/staging/condarc
 
     use_miniconda3_in_temp_for_conda_if_necessary
 
@@ -129,21 +128,9 @@ setup_target() {
         fi
     fi
     mkdir -p conda_package_cache engine_home infrastructure user_envs
-    if ! ls $RESOLVED_TARGET/condarc &> /dev/null; then
-        info 'Creating condarc symlink'
-        ln -s infrastructure/production/condarc
-    fi
     cd infrastructure
     mkdir -p blue green testing blue/{bin,etc} blue/conda/{def,envs}
     ln -s blue staging
-    touch staging/condarc
-    write_condarc
-}
-
-write_condarc() {
-    local condarc_template=$RESOURCES_DIR/condarc.m4
-    m4 -D RESOLVED_TARGET=$RESOLVED_TARGET \
-       -D ENVIRONMENT_NAME=blue $condarc_template > staging/condarc
 }
 
 get_conda() {

--- a/scripts/bootstrap_engine.py
+++ b/scripts/bootstrap_engine.py
@@ -56,6 +56,7 @@ def main(run_function=run):
     env = dict(
         HOME=home,
         CONDARC=env_path("CONDARC"),
+        CONDA_SUBDIR=environ.get("CONDA_SUBDIR", "")
     )
     info(f"{env=}")
     if len(environ["VERBOSE"]) > 1:

--- a/scripts/engine/deploy.py
+++ b/scripts/engine/deploy.py
@@ -133,7 +133,8 @@ class MambaDeployer:
                 return 0
         elif self.mode == "force":
             options.append("--force")
-        options.append("--offline")
+        if self.offline:
+            options.append("--offline")
         mamba_command = [MAMBA, "env", "create"] + options
         mamba_command += ["-n", env_name, "-f", DEFS_DIR / env_yaml]
         if self.dry_run:

--- a/scripts/engine/deploy.py
+++ b/scripts/engine/deploy.py
@@ -36,6 +36,9 @@ def deploy_tier(
     if tier_path == prod_path:
         critical(f"attempt to modify {prod_path=}")
         exit(4)
+    if tier_path.exists() and mode == "force":
+        rmtree(tier_path)
+        tier_path.mkdir()
     deployer = MambaDeployer(target, tier_path, dry_run, offline, mode, run_function)
     if deployer.mode != "keep":
         deployer.info()

--- a/scripts/engine/deploy.py
+++ b/scripts/engine/deploy.py
@@ -100,7 +100,6 @@ class MambaDeployer:
         self.meta_dir = tier_path / "meta"
         self.env = dict(
             HOME=target / "engine_home",
-            # CONDARC=tier_path / "condarc",
             CONDA_ENVS_DIRS=self.envs_dir,
             CONDA_PKGS_DIRS=target / "conda_package_cache",
             CONDA_CHANNELS="conda-forge",


### PR DESCRIPTION
Multiple fixes:

- Delete commented-out code
- Remove condarc from bootstrap.sh
- Drop user_envs from bootstrap.sh
- Don't remove infrastructure on --force
- Add git-delta to unix.yaml
- Clear out just old tier during --force deploy
- During bootstrap, only create symlink if missing
- Only pass --offline to mamba if passed to script
- Pass on CONDA_SUBDIR from environment if set
- Simplify skeleton creation
- Add ca and cda commands to simplify conda operations
- Add clean-zsh

Resolves #5.